### PR TITLE
Improvements to CI and binaries build

### DIFF
--- a/.github/workflows/wallet_build.yml
+++ b/.github/workflows/wallet_build.yml
@@ -40,6 +40,7 @@ jobs:
             target: windows-x64
 
     steps:
+
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/wallet_ci.yml
+++ b/.github/workflows/wallet_ci.yml
@@ -3,6 +3,20 @@ on: [pull_request, workflow_dispatch]
 name: Continuous integration
 
 jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: core 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
   analyze:
     name: Dusk Analyzer
     runs-on: core
@@ -20,18 +34,19 @@ jobs:
         with:
           command: dusk-analyzer
 
-  test_nightly:
-    name: Nightly tests
+  test_nightly-linux:
+    name: "[Linux] Nightly tests"
     runs-on: core 
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          components: clippy
 
       - run: rustup component add rustfmt
 
-      - run: make test
+      - run: cargo test
 
       - name: Clippy check release
         uses: actions-rs/clippy-check@v1
@@ -39,16 +54,47 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --release -- -D warnings
 
-  fmt:
-    name: Rustfmt
-    runs-on: core 
+  test_nightly-macintel:
+    name: "[Mac Intel] Nightly tests"
+    runs-on: macos-latest 
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
+
+      - name: Add arm target for Apple Silicon build
+        run: rustup target add aarch64-apple-darwin 
+
+      - run: cargo test
+
+  test_nightly-macm1:
+    name: "[Mac arm64] Nightly checks"
+    runs-on: macos-latest 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          command: fmt
-          args: --all -- --check
+          profile: minimal
+
+      - run: rustup component add rustfmt
+
+      - name: Add arm target for Apple Silicon build
+        run: rustup target add aarch64-apple-darwin 
+
+      - run: cargo check --target=aarch64-apple-darwin
+
+  test_nightly-win:
+    name: "[Windows] Nightly tests"
+    runs-on: windows-latest 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+
+      - run: rustup component add rustfmt
+
+      - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "tiny-bip39",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ dusk-plonk = { version = "0.10", default-features = false }
 dusk-jubjub = { version = "0.11", default-features = false }
 dusk-bls12_381-sign = { version = "0.3.0-rc", default-features = false, features = [ "canon" ] }
 rusk-schema = "0.1.0"
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/src/lib/store.rs
+++ b/src/lib/store.rs
@@ -237,13 +237,13 @@ impl fmt::Debug for LocalStore {
 mod tests {
 
     use super::*;
-    use std::path::PathBuf;
+    use tempfile::tempdir;
 
     #[test]
     fn test_localstore() -> Result<(), StoreError> {
         // create a wallet
-        let path = PathBuf::from("/tmp/test_wallet.dat");
-        let _ = fs::remove_file(&path);
+        let dir = tempdir()?;
+        let path = dir.path().join("test_wallet.dat");
 
         let seed = [123u8; 64];
         let st = LocalStore::new(&path, seed)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,15 +319,19 @@ async fn exec() -> Result<(), Error> {
     };
 
     // connect to rusk
-    let ipc = cfg.rusk.ipc_method.as_str();
-    #[cfg(not(windows))]
-    let rusk = match ipc {
-        "uds" => rusk_uds(&cfg.rusk.rusk_addr).await,
-        "tcp_ip" => rusk_tcp(&cfg.rusk.rusk_addr, &cfg.rusk.prover_addr).await,
-        _ => panic!("IPC method \"{}\" not supported", ipc),
-    };
     #[cfg(windows)]
     let rusk = rusk_tcp(&cfg.rusk.rusk_addr, &cfg.rusk.prover_addr).await;
+    #[cfg(not(windows))]
+    let rusk = {
+        let ipc = cfg.rusk.ipc_method.as_str();
+        match ipc {
+            "uds" => rusk_uds(&cfg.rusk.rusk_addr).await,
+            "tcp_ip" => {
+                rusk_tcp(&cfg.rusk.rusk_addr, &cfg.rusk.prover_addr).await
+            }
+            _ => panic!("IPC method \"{}\" not supported", ipc),
+        }
+    };
 
     // graphql helper
     let gql = GraphQL::new(&cfg.chain.gql_url.clone());


### PR DESCRIPTION
- Fix test steps to be integrated with proper matrix run
- Fix CI to disable Carriage Returns on Windows
- Fix action by removing toolchain override
- Fix wrong hardcoded path failing on Windows
- Rename CI files, added Windows tests on standard CI
- Fix CI naming to reflect OS where it's running
- Fix to eliminate carriage returns on windows git pulls
- Fix CI to include Mac Intel builds, switched M1 to checks
- Fix CI to remove --release flag from builds
- Fix CI to exclude tests from wallet builds (now all moved to test CI)

Fixes #15 