### PR TITLE
Withdraw stake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Withdraw reward command [#26]
+
 ### Changed
 
 - Adapt balance to the new State [#24]
-- Rename `withdraw-stake` to `unstake`
+- Rename `withdraw-stake` to `unstake` [#26]
 - Introduce Dusk type for currency management [#4]
 
 
@@ -175,6 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `Store` trait from `wallet-core`
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
+[#26]: https://github.com/dusk-network/wallet-cli/issues/26
 [#24]: https://github.com/dusk-network/wallet-cli/issues/24
 [#18]: https://github.com/dusk-network/wallet-cli/issues/18
 [#6]: https://github.com/dusk-network/wallet-cli/issues/6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-wallet"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ SUBCOMMANDS:
     stake          Start staking DUSK
     stake-info     Check your stake
     unstake        Unstake a key's stake
+    withdraw       Withdraw accumulated reward for a stake key
     export         Export BLS provisioner key pair
     interactive    Run in interactive mode (default)
     help           Print this message or the help of the given subcommand(s)

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,29 @@ enum CliCommand {
         gas_price: Option<Lux>,
     },
 
+    /// Withdraw accumulated reward for a stake key
+    Withdraw {
+        /// Key index to pay transaction costs
+        #[clap(short, long, default_value_t = 0)]
+        key: u64,
+
+        /// Stake key index with the accumulated reward
+        #[clap(short, long, default_value_t = 0)]
+        stake_key: u64,
+
+        /// Address to which the reward will be sent to
+        #[clap(short, long)]
+        refund_addr: String,
+
+        /// Max amt of gas for this transaction
+        #[clap(short = 'l', long)]
+        gas_limit: Option<u64>,
+
+        /// Max price you're willing to pay for gas used (in LUX)
+        #[clap(short = 'p', long)]
+        gas_price: Option<Lux>,
+    },
+
     /// Export BLS provisioner key pair
     Export {
         /// Key index from which your DUSK was staked


### PR DESCRIPTION
This PR adds the `withdraw` stake reward command to the CLI and removes the local rusk precondition for staking, thus completing the new stake spec.

Resolves #26 