### PR TITLE
Enhance address validity checks on interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enhance address validity checks on interactive mode [#28]
 - Prevent exit on prepare command errors [#27]
 - Adapt balance to the new State [#24]
 - Rename `withdraw-stake` to `unstake` [#26]
@@ -180,6 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `Store` trait from `wallet-core`
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
+[#28]: https://github.com/dusk-network/wallet-cli/issues/28
 [#27]: https://github.com/dusk-network/wallet-cli/issues/27
 [#26]: https://github.com/dusk-network/wallet-cli/issues/26
 [#24]: https://github.com/dusk-network/wallet-cli/issues/24

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -19,6 +19,8 @@ pub(crate) mod wallet;
 
 pub(crate) const SEED_SIZE: usize = 64;
 
+pub(crate) const ADDR_LEN: usize = 88;
+
 pub(crate) const MAX_CONVERTIBLE: Dusk = Dusk::MAX;
 pub(crate) const MIN_CONVERTIBLE: Dusk = Dusk::new(1);
 

--- a/src/lib/prompt.rs
+++ b/src/lib/prompt.rs
@@ -23,8 +23,8 @@ use super::store::LocalStore;
 use crate::lib::crypto::MnemSeed;
 use crate::lib::dusk::Dusk;
 use crate::lib::{
-    DEFAULT_GAS_LIMIT, DEFAULT_GAS_PRICE, MAX_CONVERTIBLE, MIN_CONVERTIBLE,
-    MIN_GAS_LIMIT,
+    ADDR_LEN, DEFAULT_GAS_LIMIT, DEFAULT_GAS_PRICE, MAX_CONVERTIBLE,
+    MIN_CONVERTIBLE, MIN_GAS_LIMIT,
 };
 use crate::{CliCommand, Error};
 
@@ -473,7 +473,7 @@ fn request_rcvr_addr(addr_for: &str) -> String {
 
 /// Utility function to check if an address is valid
 fn is_valid_addr(addr: &str) -> bool {
-    !addr.is_empty() && bs58::decode(addr).into_vec().is_ok()
+    addr.len() == ADDR_LEN && bs58::decode(addr).into_vec().is_ok()
 }
 
 /// Checks for a valid DUSK denomination


### PR DESCRIPTION
Addresses inputed by users in interactive mode are now required to be 88 bytes long as per the base58 spec.

Resolves #28