### PR TITLE
Release 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2022-05-04
+
 ### Added
 
 - Block trait for easier blocking on futures [#32]
@@ -236,7 +238,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/dusk-network/wallet-cli/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/dusk-network/wallet-cli/compare/v0.5.2...v0.7.0
 [0.5.2]: https://github.com/dusk-network/wallet-cli/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/dusk-network/wallet-cli/compare/v0.5.0...v0.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-wallet"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## [0.8.0] - 2022-05-04

### Added

- Block trait for easier blocking on futures [#32]
- Withdraw reward command [#26]

### Changed

- Upgraded cache implementation to use `microkelvin` instead of `rusqlite` [#32]
- Use streaming `GetNotes` call instead of `GetNotesOwnedBy` [#32]
- Enhance address validity checks on interactive mode [#28]
- Prevent exit on prepare command errors [#27]
- Adapt balance to the new State [#24]
- Rename `withdraw-stake` to `unstake` [#26]
- Introduce Dusk type for currency management [#4]

### Fixed

- Fix cache bug preventing adding all notes to it [#35]
- Fix address validation by parsing address first [#35]