### PR TITLE
Decouple command outputs between interactive and headless modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Flag `--spendable` to `Balance` command [#40]
+- Flag `--reward` to `StakeInfo` command [#40]
+
+### Changed
+- Commands run in headless mode do not provide dynamic status updates [#40]
+
 ## [0.8.0] - 2022-05-04
 
 ### Added
@@ -190,6 +197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `Store` trait from `wallet-core`
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
+[#40]: https://github.com/dusk-network/wallet-cli/issues/40
 [#35]: https://github.com/dusk-network/wallet-cli/issues/35
 [#32]: https://github.com/dusk-network/wallet-cli/issues/32
 [#28]: https://github.com/dusk-network/wallet-cli/issues/28

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-wallet"
-version = "0.8.0"
+version = "0.9.0-rc.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.8.0"
+version = "0.9.0-rc.0"
 edition = "2021"
 
 [dependencies]

--- a/src/lib/prompt.rs
+++ b/src/lib/prompt.rs
@@ -292,7 +292,10 @@ pub(crate) fn prepare_command(
         // Public spend key
         Prompt::Address(key) => Ok(Some(Cli::Address { key })),
         // Check balance
-        Prompt::Balance(key) => Ok(Some(Cli::Balance { key })),
+        Prompt::Balance(key) => Ok(Some(Cli::Balance {
+            key,
+            spendable: false,
+        })),
         // Create transfer
         Prompt::Transfer(key) => {
             if balance == 0.0 {
@@ -328,7 +331,9 @@ pub(crate) fn prepare_command(
             }
         }
         // Stake info
-        Prompt::StakeInfo(key) => Ok(Some(Cli::StakeInfo { key })),
+        Prompt::StakeInfo(key) => {
+            Ok(Some(Cli::StakeInfo { key, reward: false }))
+        }
         // Unstake
         Prompt::Unstake(key) => {
             if balance == 0.0 {


### PR DESCRIPTION
This is a necessary first step to practically solve #11 

Besides structural changes, this PR introduces these user-facing changes: 
- New `--spendable` flag to `Balance` command
- New `--reward` flag to `StakeInfo` command
- No more dynamic status updates in headless mode (for now)

Resolves #40 
