### PR TITLE
Add rusk version headers to all gRPC requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Flag `--spendable` to `Balance` command [#40]
+- Flag `--reward` to `StakeInfo` command [#40]
+
+### Changed
+- Commands run in headless mode do not provide dynamic status updates [#40]
+
 ## [0.8.0] - 2022-05-04
 
 ### Added
@@ -190,6 +197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `Store` trait from `wallet-core`
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
+[#40]: https://github.com/dusk-network/wallet-cli/issues/40
 [#35]: https://github.com/dusk-network/wallet-cli/issues/35
 [#32]: https://github.com/dusk-network/wallet-cli/issues/32
 [#28]: https://github.com/dusk-network/wallet-cli/issues/28

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "rusk-wallet"
-version = "0.8.0"
+version = "0.9.0-rc.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-wallet"
-version = "0.8.0"
+version = "0.9.0-rc.0"
 edition = "2021"
 
 [dependencies]

--- a/src/lib/cache.rs
+++ b/src/lib/cache.rs
@@ -64,11 +64,15 @@ impl Cache {
     /// requirement for being able to instantiate a cache using [`new`].
     ///
     /// # Panics
-    /// If data dir does not exist or is not a directory, or if called more than
-    /// once.
+    /// If called more than once or if unable to remove old cache file.
     pub(crate) fn set_data_path(data_dir: PathBuf) -> Result<(), StateError> {
-        if !(data_dir.exists() && data_dir.is_dir()) {
-            panic!("cache path does not exist or is not a directory");
+        // remove old cache if it's still there
+        let db_path = data_dir.join("cache.db");
+        if db_path.exists()
+            && !db_path.is_dir()
+            && fs::remove_file(&db_path).is_err()
+        {
+            panic!("Failed to remove old cache files. Please remove {} manually and try again.", db_path.display())
         }
 
         CACHE_DATA_PATH

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -131,7 +131,6 @@ impl Config {
 
                 match fs::write(&file, &default) {
                     Ok(_) => println!("Default configuration generated: {}", file.display()),
-
                     Err(e) => println!(
                         "Default configuration generated; failed to write in {}: {}",
                         file.display(),

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -7,6 +7,7 @@
 use phoenix_core::Error as PhoenixError;
 use rand_core::Error as RngError;
 use std::{fmt, io};
+use tonic::codegen::http;
 
 use super::clients;
 
@@ -26,6 +27,8 @@ pub enum Error {
     GraphQL(GraphQLError),
     /// Network error
     Network(tonic::transport::Error),
+    /// Rusk uri failure
+    RuskURI(http::uri::InvalidUri),
     /// Rusk connection failure
     RuskConn(tonic::transport::Error),
     /// Prover cluster connection failure
@@ -98,6 +101,12 @@ impl From<dusk_bytes::Error> for Error {
     }
 }
 
+impl From<http::uri::InvalidUri> for Error {
+    fn from(e: http::uri::InvalidUri) -> Self {
+        Self::RuskURI(e)
+    }
+}
+
 impl From<tonic::transport::Error> for Error {
     fn from(e: tonic::transport::Error) -> Self {
         Self::Network(e)
@@ -163,6 +172,7 @@ impl fmt::Display for Error {
             Error::Prover(err) => write!(f, "\r{}", err),
             Error::Store(err) => write!(f, "\r{}", err),
             Error::GraphQL(err) => write!(f, "\r{}", err),
+            Error::RuskURI(err) => write!(f, "\rInvalid URI provided for Rusk:\n{}", err),
             Error::Network(err) => write!(f, "\rA network error occurred while communicating with Rusk:\n{}", err),
             Error::RuskConn(err) => write!(f, "\rCouldn't establish connection with Rusk: {}\nPlease check your settings and try again.", err),
             Error::ProverConn(err) => write!(f, "\rCouldn't establish connection with the prover cluster: {}\nPlease check your settings and try again.", err),
@@ -194,6 +204,7 @@ impl fmt::Debug for Error {
             Error::Prover(err) => write!(f, "\r{:?}", err),
             Error::Store(err) => write!(f, "\r{:?}", err),
             Error::GraphQL(err) => write!(f, "\r{:?}", err),
+            Error::RuskURI(err) => write!(f, "\rInvalid URI provided for Rusk:\n{:?}", err),
             Error::Network(err) => write!(f, "\rA network error occurred while communicating with Rusk:\n{:?}", err),
             Error::RuskConn(err) => write!(f, "\rCouldn't establish connection with Rusk:\n{:?}", err),
             Error::ProverConn(err) => write!(f, "\rCouldn't establish connection with the prover cluster:\n{:?}", err),

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod dusk;
 pub(crate) mod error;
 pub(crate) mod gql;
 pub(crate) mod prompt;
+pub(crate) mod rusk;
 pub(crate) mod store;
 pub(crate) mod wallet;
 

--- a/src/lib/prompt.rs
+++ b/src/lib/prompt.rs
@@ -292,7 +292,10 @@ pub(crate) fn prepare_command(
         // Public spend key
         Prompt::Address(key) => Ok(Some(Cli::Address { key })),
         // Check balance
-        Prompt::Balance(key) => Ok(Some(Cli::Balance { key })),
+        Prompt::Balance(key) => Ok(Some(Cli::Balance {
+            key,
+            spendable: false,
+        })),
         // Create transfer
         Prompt::Transfer(key) => {
             if balance == 0.0 {
@@ -328,7 +331,9 @@ pub(crate) fn prepare_command(
             }
         }
         // Stake info
-        Prompt::StakeInfo(key) => Ok(Some(Cli::StakeInfo { key })),
+        Prompt::StakeInfo(key) => {
+            Ok(Some(Cli::StakeInfo { key, reward: false }))
+        }
         // Unstake
         Prompt::Unstake(key) => {
             if balance == 0.0 {

--- a/src/lib/rusk.rs
+++ b/src/lib/rusk.rs
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::str::FromStr;
+
+use tonic::codegen::InterceptedService;
+use tonic::metadata::MetadataValue;
+use tonic::service::Interceptor;
+use tonic::transport::{Endpoint, Channel};
+use tonic::Status;
+
+use rusk_schema::network_client::NetworkClient as GrpcNetworkClient;
+use rusk_schema::prover_client::ProverClient as GrpcProverClient;
+use rusk_schema::state_client::StateClient as GrpcStateClient;
+
+#[cfg(not(windows))]
+use tokio::net::UnixStream;
+#[cfg(not(windows))]
+use tonic::transport::Uri;
+#[cfg(not(windows))]
+use tower::service_fn;
+
+use crate::Error;
+
+/// Supported Rusk version
+const REQUIRED_RUSK_VERSION: &str = "0.5.0-rc.0";
+
+/// Rusk service clients all include versioning middleware
+pub(crate) type RuskNetworkClient =
+    GrpcNetworkClient<InterceptedService<Channel, RuskVersionInterceptor>>;
+pub(crate) type RuskStateClient =
+    GrpcStateClient<InterceptedService<Channel, RuskVersionInterceptor>>;
+pub(crate) type RuskProverClient =
+    GrpcProverClient<InterceptedService<Channel, RuskVersionInterceptor>>;
+
+/// Clients to Rusk services
+pub struct RuskClient {
+    pub network: RuskNetworkClient,
+    pub state: RuskStateClient,
+    pub prover: RuskProverClient,
+}
+
+impl RuskClient {
+    /// Creates a `Rusk` instance and attempts to connect
+    /// all clients via TCP.
+    pub async fn with_tcp(
+        rusk_addr: &str,
+        prov_addr: &str,
+    ) -> Result<RuskClient, Error> {
+        let rusk_chan = Endpoint::from_str(rusk_addr)?
+            .connect()
+            .await
+            .map_err(Error::RuskConn)?;
+        let prov_chan = Endpoint::from_str(prov_addr)?
+            .connect()
+            .await
+            .map_err(Error::RuskConn)?;
+
+        Ok(RuskClient {
+            network: GrpcNetworkClient::with_interceptor(
+                rusk_chan.clone(),
+                RuskVersionInterceptor,
+            ),
+            state: GrpcStateClient::with_interceptor(
+                rusk_chan,
+                RuskVersionInterceptor,
+            ),
+            prover: GrpcProverClient::with_interceptor(
+                prov_chan,
+                RuskVersionInterceptor,
+            ),
+        })
+    }
+
+    /// Creates a `Rusk` instance and attempts to connect
+    /// all clients via UDS (unix domain sockets).
+    #[cfg(not(windows))]
+    pub async fn with_uds(socket_path: &str) -> Result<RuskClient, Error> {
+        let socket_path = socket_path.to_string();
+        let channel = Endpoint::try_from("http://[::]:50051")
+            .expect("parse address")
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let path = (&socket_path[..]).to_string();
+                UnixStream::connect(path)
+            }))
+            .await?;
+
+        Ok(RuskClient {
+            network: GrpcNetworkClient::with_interceptor(
+                channel.clone(),
+                RuskVersionInterceptor,
+            ),
+            state: GrpcStateClient::with_interceptor(
+                channel.clone(),
+                RuskVersionInterceptor,
+            ),
+            prover: GrpcProverClient::with_interceptor(
+                channel,
+                RuskVersionInterceptor,
+            ),
+        })
+    }
+}
+
+/// Adds the compatible Rusk version in every request's gRPC headers
+#[derive(Clone)]
+pub struct RuskVersionInterceptor;
+
+impl Interceptor for RuskVersionInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, Status> {
+        // add `x-rusk-version` to header metadata
+        let md = request.metadata_mut();
+        md.append(
+            "x-rusk-version",
+            MetadataValue::from_static(REQUIRED_RUSK_VERSION),
+        );
+        Ok(request)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,27 +10,15 @@ pub use lib::error::{Error, ProverError, StateError, StoreError};
 use clap::{AppSettings, Parser, Subcommand};
 use std::path::{Path, PathBuf};
 
-#[cfg(not(windows))]
-use tokio::net::UnixStream;
-#[cfg(not(windows))]
-use tonic::transport::{Endpoint, Uri};
-#[cfg(not(windows))]
-use tower::service_fn;
-
-use tonic::transport::Channel;
-
 use lib::clients::{Prover, State};
 use lib::config::Config;
 use lib::crypto::MnemSeed;
 use lib::dusk::{Dusk, Lux};
 use lib::gql::GraphQL;
 use lib::prompt;
+use lib::rusk::RuskClient;
 use lib::store::LocalStore;
 use lib::wallet::CliWallet;
-
-use rusk_schema::network_client::NetworkClient;
-use rusk_schema::prover_client::ProverClient;
-use rusk_schema::state_client::StateClient;
 
 /// The CLI Wallet
 #[derive(Parser)]
@@ -224,47 +212,6 @@ impl CliCommand {
     }
 }
 
-/// Client connections to rusk Services
-struct Rusk {
-    network: NetworkClient<Channel>,
-    state: StateClient<Channel>,
-    prover: ProverClient<Channel>,
-}
-
-/// Connect to rusk services via TCP
-async fn rusk_tcp(rusk_addr: &str, prov_addr: &str) -> Result<Rusk, Error> {
-    Ok(Rusk {
-        network: NetworkClient::connect(rusk_addr.to_string())
-            .await
-            .map_err(Error::RuskConn)?,
-        state: StateClient::connect(rusk_addr.to_string())
-            .await
-            .map_err(Error::RuskConn)?,
-        prover: ProverClient::connect(prov_addr.to_string())
-            .await
-            .map_err(Error::ProverConn)?,
-    })
-}
-
-/// Connect to rusk via UDS (Unix domain sockets)
-#[cfg(not(windows))]
-async fn rusk_uds(socket_path: &str) -> Result<Rusk, Error> {
-    let socket_path = socket_path.to_string();
-    let channel = Endpoint::try_from("http://[::]:50051")
-        .expect("parse address")
-        .connect_with_connector(service_fn(move |_: Uri| {
-            let path = (&socket_path[..]).to_string();
-            UnixStream::connect(path)
-        }))
-        .await?;
-
-    Ok(Rusk {
-        network: NetworkClient::new(channel.clone()),
-        state: StateClient::new(channel.clone()),
-        prover: ProverClient::new(channel),
-    })
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     if let Err(err) = exec().await {
@@ -351,16 +298,16 @@ async fn exec() -> Result<(), Error> {
         _ => LocalStore::from_file(&wallet_path, pwd)?,
     };
 
-    // connect to rusk
+    // attempt to connect to rusk
     #[cfg(windows)]
-    let rusk = rusk_tcp(&cfg.rusk.rusk_addr, &cfg.rusk.prover_addr).await;
+    let rusk = RuskClient::with_tcp(&cfg.rusk.rusk_addr, &cfg.rusk.prover_addr).await;
     #[cfg(not(windows))]
     let rusk = {
         let ipc = cfg.rusk.ipc_method.as_str();
         match ipc {
-            "uds" => rusk_uds(&cfg.rusk.rusk_addr).await,
+            "uds" => RuskClient::with_uds(&cfg.rusk.rusk_addr).await,
             "tcp_ip" => {
-                rusk_tcp(&cfg.rusk.rusk_addr, &cfg.rusk.prover_addr).await
+                RuskClient::with_tcp(&cfg.rusk.rusk_addr, &cfg.rusk.prover_addr).await
             }
             _ => panic!("IPC method \"{}\" not supported", ipc),
         }
@@ -372,6 +319,8 @@ async fn exec() -> Result<(), Error> {
     // create our wallet
     let wallet = match rusk {
         Ok(clients) => {
+
+            // wallet-core prover client
             let prover = Prover::new(
                 clients.prover,
                 clients.state.clone(),
@@ -381,18 +330,19 @@ async fn exec() -> Result<(), Error> {
                 quiet,
             );
 
+            // wallet-core state client
             State::set_cache_dir(cfg.wallet.data_dir.clone())?;
             let state = State::new(clients.state, quiet)?;
 
+            // create the wallet
             CliWallet::new(cfg, store, state, prover)
+
         }
         Err(err) => {
             println!("\r{}", err);
             CliWallet::offline(cfg, store)
         }
     };
-
-    // run command(s)
 
     // run command(s)
     match cmd {


### PR DESCRIPTION
While resolving #43, I took the chance to do a bit of refactoring, resulting in `Rusk` structure moving to its own type outside the `main.rs`. It feels appropriate to have it somewhere else now that it's become a little bigger, as the `Interceptor` in charge of introducing the headers creates some noise in the code.

Resolves #43

See also https://github.com/dusk-network/rusk/pull/718