### PR TITLE
Add rusk version headers to all gRPC requests

### DIFF
--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -131,7 +131,6 @@ impl Config {
 
                 match fs::write(&file, &default) {
                     Ok(_) => println!("Default configuration generated: {}", file.display()),
-
                     Err(e) => println!(
                         "Default configuration generated; failed to write in {}: {}",
                         file.display(),

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -7,6 +7,7 @@
 use phoenix_core::Error as PhoenixError;
 use rand_core::Error as RngError;
 use std::{fmt, io};
+use tonic::codegen::http;
 
 use super::clients;
 
@@ -26,6 +27,8 @@ pub enum Error {
     GraphQL(GraphQLError),
     /// Network error
     Network(tonic::transport::Error),
+    /// Rusk uri failure
+    RuskURI(http::uri::InvalidUri),
     /// Rusk connection failure
     RuskConn(tonic::transport::Error),
     /// Prover cluster connection failure
@@ -98,6 +101,12 @@ impl From<dusk_bytes::Error> for Error {
     }
 }
 
+impl From<http::uri::InvalidUri> for Error {
+    fn from(e: http::uri::InvalidUri) -> Self {
+        Self::RuskURI(e)
+    }
+}
+
 impl From<tonic::transport::Error> for Error {
     fn from(e: tonic::transport::Error) -> Self {
         Self::Network(e)
@@ -163,6 +172,7 @@ impl fmt::Display for Error {
             Error::Prover(err) => write!(f, "\r{}", err),
             Error::Store(err) => write!(f, "\r{}", err),
             Error::GraphQL(err) => write!(f, "\r{}", err),
+            Error::RuskURI(err) => write!(f, "\rInvalid URI provided for Rusk:\n{}", err),
             Error::Network(err) => write!(f, "\rA network error occurred while communicating with Rusk:\n{}", err),
             Error::RuskConn(err) => write!(f, "\rCouldn't establish connection with Rusk: {}\nPlease check your settings and try again.", err),
             Error::ProverConn(err) => write!(f, "\rCouldn't establish connection with the prover cluster: {}\nPlease check your settings and try again.", err),
@@ -194,6 +204,7 @@ impl fmt::Debug for Error {
             Error::Prover(err) => write!(f, "\r{:?}", err),
             Error::Store(err) => write!(f, "\r{:?}", err),
             Error::GraphQL(err) => write!(f, "\r{:?}", err),
+            Error::RuskURI(err) => write!(f, "\rInvalid URI provided for Rusk:\n{:?}", err),
             Error::Network(err) => write!(f, "\rA network error occurred while communicating with Rusk:\n{:?}", err),
             Error::RuskConn(err) => write!(f, "\rCouldn't establish connection with Rusk:\n{:?}", err),
             Error::ProverConn(err) => write!(f, "\rCouldn't establish connection with the prover cluster:\n{:?}", err),

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod dusk;
 pub(crate) mod error;
 pub(crate) mod gql;
 pub(crate) mod prompt;
+pub(crate) mod rusk;
 pub(crate) mod store;
 pub(crate) mod wallet;
 

--- a/src/lib/rusk.rs
+++ b/src/lib/rusk.rs
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::str::FromStr;
+
+use tonic::codegen::InterceptedService;
+use tonic::metadata::MetadataValue;
+use tonic::service::Interceptor;
+use tonic::transport::{Channel, Endpoint};
+use tonic::Status;
+
+use rusk_schema::network_client::NetworkClient as GrpcNetworkClient;
+use rusk_schema::prover_client::ProverClient as GrpcProverClient;
+use rusk_schema::state_client::StateClient as GrpcStateClient;
+
+#[cfg(not(windows))]
+use tokio::net::UnixStream;
+#[cfg(not(windows))]
+use tonic::transport::Uri;
+#[cfg(not(windows))]
+use tower::service_fn;
+
+use crate::Error;
+
+/// Supported Rusk version
+const REQUIRED_RUSK_VERSION: &str = "0.5.0-rc.0";
+
+/// Rusk service clients all include versioning middleware
+pub(crate) type RuskNetworkClient =
+    GrpcNetworkClient<InterceptedService<Channel, RuskVersionInterceptor>>;
+pub(crate) type RuskStateClient =
+    GrpcStateClient<InterceptedService<Channel, RuskVersionInterceptor>>;
+pub(crate) type RuskProverClient =
+    GrpcProverClient<InterceptedService<Channel, RuskVersionInterceptor>>;
+
+/// Clients to Rusk services
+pub struct RuskClient {
+    pub network: RuskNetworkClient,
+    pub state: RuskStateClient,
+    pub prover: RuskProverClient,
+}
+
+impl RuskClient {
+    /// Creates a `Rusk` instance and attempts to connect
+    /// all clients via TCP.
+    pub async fn with_tcp(
+        rusk_addr: &str,
+        prov_addr: &str,
+    ) -> Result<RuskClient, Error> {
+        let rusk_chan = Endpoint::from_str(rusk_addr)?
+            .connect()
+            .await
+            .map_err(Error::RuskConn)?;
+        let prov_chan = Endpoint::from_str(prov_addr)?
+            .connect()
+            .await
+            .map_err(Error::RuskConn)?;
+
+        Ok(RuskClient {
+            network: GrpcNetworkClient::with_interceptor(
+                rusk_chan.clone(),
+                RuskVersionInterceptor,
+            ),
+            state: GrpcStateClient::with_interceptor(
+                rusk_chan,
+                RuskVersionInterceptor,
+            ),
+            prover: GrpcProverClient::with_interceptor(
+                prov_chan,
+                RuskVersionInterceptor,
+            ),
+        })
+    }
+
+    /// Creates a `Rusk` instance and attempts to connect
+    /// all clients via UDS (unix domain sockets).
+    #[cfg(not(windows))]
+    pub async fn with_uds(socket_path: &str) -> Result<RuskClient, Error> {
+        let socket_path = socket_path.to_string();
+        let channel = Endpoint::try_from("http://[::]:50051")
+            .expect("parse address")
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let path = (&socket_path[..]).to_string();
+                UnixStream::connect(path)
+            }))
+            .await?;
+
+        Ok(RuskClient {
+            network: GrpcNetworkClient::with_interceptor(
+                channel.clone(),
+                RuskVersionInterceptor,
+            ),
+            state: GrpcStateClient::with_interceptor(
+                channel.clone(),
+                RuskVersionInterceptor,
+            ),
+            prover: GrpcProverClient::with_interceptor(
+                channel,
+                RuskVersionInterceptor,
+            ),
+        })
+    }
+}
+
+/// Adds the compatible Rusk version in every request's gRPC headers
+#[derive(Clone)]
+pub struct RuskVersionInterceptor;
+
+impl Interceptor for RuskVersionInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, Status> {
+        // add `x-rusk-version` to header metadata
+        let md = request.metadata_mut();
+        md.append(
+            "x-rusk-version",
+            MetadataValue::from_static(REQUIRED_RUSK_VERSION),
+        );
+        Ok(request)
+    }
+}


### PR DESCRIPTION
While resolving #43, I took the chance to do a bit of refactoring, resulting in `Rusk` structure moving to its own `RuskClient` type outside the `main.rs`. It feels appropriate to have it somewhere else now that it's become a little bigger, as the `Interceptor` in charge of introducing the headers creates some noise in the code.

Resolves #43

See also https://github.com/dusk-network/rusk/pull/718