### PR TITLE
Setup proper logging capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New public `Wallet` struct exposing all wallet operations as library [#54]
 - New `Address` type to identify and work with addresses [#54]
+- Logging capabilities with customizable `log_level` and `log_type` [#11]
 
 ### Changed
 - Project is now a public facing library [#54]
 - Our reference implementation is included under `src/bin` [#54]
 - UX flow is now address-based to match that of the web wallet [#59]
+- Anything that's not strictly program output is redirected to stderr [#11]
 
 ## [0.10.0] - 2022-07-06
 
@@ -227,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `Store` trait from `wallet-core`
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
+[#11]: https://github.com/dusk-network/wallet-cli/issues/11
 [#59]: https://github.com/dusk-network/wallet-cli/issues/59
 [#54]: https://github.com/dusk-network/wallet-cli/issues/54
 [#51]: https://github.com/dusk-network/wallet-cli/issues/51

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ bs58 = "0.4"
 rand = "0.8"
 aes = "0.7"
 
-
 dusk-wallet-core = "0.14.0-rc"
 canonical = "0.7"
 canonical_derive = "0.7"
@@ -60,6 +59,8 @@ dusk-bls12_381-sign = { version = "0.3.0-rc", default-features = false, features
 rusk-schema = "0.4.0"
 microkelvin = { version = "0.15.0-rc", features = ["persistence"] }
 
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.0", features = ["fmt", "env-filter", "json"] }
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ OPTIONS:
             Skip wallet recovery phrase (useful for headless wallet creation)
 
         --wait-for-tx <WAIT_FOR_TX>
-            Wait for transaction confirmation from network
+            Wait for transaction confirmation from network [possible values: true, false]
+
+        --log-level <LOG_LEVEL>
+            Output log level
+
+        --log-type <LOG_TYPE>
+            Logging output type (valid: "json", "plain", "coloured")
 
     -h, --help
             Print help information
@@ -42,10 +48,10 @@ SUBCOMMANDS:
     create         Create a new wallet
     restore        Restore a lost wallet
     balance        Check your current balance
-    address        Retrieve public spend key
+    address        Generate new addresses or list your existing ones
     transfer       Send DUSK through the network
     stake          Start staking DUSK
-    stake-info     Check your stake
+    stake-info     Check your stake information
     unstake        Unstake a key's stake
     withdraw       Withdraw accumulated reward for a stake key
     export         Export BLS provisioner key pair

--- a/config.toml
+++ b/config.toml
@@ -10,3 +10,8 @@ tx_url = "https://explorer.dusk.network/transactions/transaction/?id="
 
 [chain]
 gql_url = "http://nodes.dusk.network:9500/graphql"
+
+[logging]
+level = "info"
+type = "coloured"
+

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -33,7 +33,7 @@ pub(crate) enum Command {
         spendable: bool,
     },
 
-    /// Generate new addresses or list of your existing ones
+    /// Generate new addresses or list your existing ones
     Address {
         /// Returns list of existing addresses
         #[clap(short, long, action)]
@@ -143,6 +143,11 @@ pub(crate) enum Command {
 }
 
 impl Command {
+    /// Returns true if command runs in headless mode
+    pub fn is_headless(&self) -> bool {
+        !matches!(*self, Self::Interactive)
+    }
+
     /// Runs the command with the provided wallet
     pub async fn run(
         self,

--- a/src/bin/error.rs
+++ b/src/bin/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     NotSupported,
     /// Transaction verification errors
     Transaction(String),
+    /// Logging-related error
+    LoggingError(String),
 }
 
 impl From<crate::io::GraphQLError> for Error {
@@ -53,6 +55,18 @@ impl From<dusk_wallet::Error> for Error {
     }
 }
 
+impl From<tracing::dispatcher::SetGlobalDefaultError> for Error {
+    fn from(err: tracing::dispatcher::SetGlobalDefaultError) -> Self {
+        Self::LoggingError(err.to_string())
+    }
+}
+
+impl From<tracing::metadata::ParseLevelError> for Error {
+    fn from(err: tracing::metadata::ParseLevelError) -> Self {
+        Self::LoggingError(err.to_string())
+    }
+}
+
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -73,6 +87,7 @@ impl std::fmt::Display for Error {
                 write!(f, "This command doesn't need a wallet.")
             }
             Error::Transaction(err) => write!(f, "Transaction failed: {}", err),
+            Error::LoggingError(err) => write!(f, "Logging error: {}", err),
         }
     }
 }

--- a/src/bin/interactive.rs
+++ b/src/bin/interactive.rs
@@ -78,7 +78,7 @@ pub(crate) async fn run_loop(
                                     if cfg.chain.wait_for_tx {
                                         let gql = GraphQL::new(
                                             &cfg.chain.gql_url,
-                                            io::status,
+                                            io::status::interactive,
                                         );
                                         gql.wait_for(&txh).await?;
                                     }

--- a/src/bin/io/args.rs
+++ b/src/bin/io/args.rs
@@ -48,6 +48,14 @@ pub(crate) struct WalletArgs {
     #[clap(long, action)]
     pub wait_for_tx: Option<bool>,
 
+    /// Output log level
+    #[clap(long)]
+    pub log_level: Option<String>,
+
+    /// Logging output type (valid: "json", "plain", "coloured")
+    #[clap(long)]
+    pub log_type: Option<String>,
+
     /// Command
     #[clap(subcommand)]
     pub command: Option<Command>,

--- a/src/bin/io/mod.rs
+++ b/src/bin/io/mod.rs
@@ -7,11 +7,10 @@
 mod args;
 mod config;
 mod gql;
-mod status;
 
 pub(crate) mod prompt;
+pub(crate) mod status;
 
 pub(crate) use args::WalletArgs;
 pub(crate) use config::Config;
 pub(crate) use gql::{GraphQL, GraphQLError};
-pub(crate) use status::status;

--- a/src/bin/io/status.rs
+++ b/src/bin/io/status.rs
@@ -7,9 +7,13 @@
 use std::io::{stdout, Write};
 use std::thread;
 use std::time::Duration;
+
+use tracing::info;
+
 const STATUS_SIZE: usize = 35;
 
-pub(crate) fn status(status: &str) {
+/// Prints an interactive status message
+pub(crate) fn interactive(status: &str) {
     let filln = STATUS_SIZE - status.len();
     let fill = if filln > 0 {
         " ".repeat(filln)
@@ -20,4 +24,9 @@ pub(crate) fn status(status: &str) {
     let mut stdout = stdout();
     stdout.flush().unwrap();
     thread::sleep(Duration::from_millis(85));
+}
+
+/// Logs the status message at info level
+pub(crate) fn headless(status: &str) {
+    info!(status);
 }


### PR DESCRIPTION
This PR adds proper logging capabilities to the wallet.

User can now set `log_level` and `log_type` as runtime args or through configuration file.

In headless mode, anything that's not strictly program output will be redirected to `stderr`.

Resolves #11 