### PR TITLE
Running `v0.11.0` with pre-existing wallet data makes the exec dies silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Add Windows terminal compatibility [#68]
+
+### Changed
+
+- Change `LoggingConfig` to be optional [#73]
+- Replace `error!` macro with `eprintln!` macro [#73]
 
 ## [0.11.0] - 2022-08-17
 
@@ -235,6 +242,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of `Store` trait from `wallet-core`
 - Implementation of `State` and `Prover` traits from `wallet-core`
 
+[#73]: https://github.com/dusk-network/wallet-cli/issues/73
 [#68]: https://github.com/dusk-network/wallet-cli/issues/68
 [#11]: https://github.com/dusk-network/wallet-cli/issues/11
 [#59]: https://github.com/dusk-network/wallet-cli/issues/59

--- a/src/bin/io/config.rs
+++ b/src/bin/io/config.rs
@@ -30,7 +30,7 @@ mod parser {
         pub rusk: ParsedRuskConfig,
         pub explorer: ParsedExplorerConfig,
         pub chain: ParsedChainConfig,
-        pub logging: LoggingConfig,
+        pub logging: Option<LoggingConfig>,
     }
 
     #[derive(Deserialize)]
@@ -250,12 +250,16 @@ impl From<parser::ParsedConfig> for Config {
             logging: LoggingConfig {
                 level: parsed
                     .logging
-                    .level
-                    .unwrap_or_else(|| "info".to_string()),
+                    .as_ref()
+                    .and_then(|parsed| parsed.level.as_ref())
+                    .unwrap_or(&"info".to_string())
+                    .into(),
                 r#type: parsed
                     .logging
-                    .r#type
-                    .unwrap_or_else(|| "coloured".to_string()),
+                    .as_ref()
+                    .and_then(|parsed| parsed.r#type.as_ref())
+                    .unwrap_or(&"coloured".to_string())
+                    .into(),
             },
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::{error, warn, Level};
+use tracing::{warn, Level};
 
 use bip39::{Language, Mnemonic, MnemonicType};
 use blake3::Hash;
@@ -51,7 +51,7 @@ impl SecureWalletFile for WalletFile {
 async fn main() -> Result<(), Error> {
     if let Err(err) = exec().await {
         // display the error message (if any)
-        error!("{}", err);
+        eprintln!("{}", err);
         // give cursor back to the user
         io::prompt::show_cursor()?;
     }
@@ -87,6 +87,16 @@ async fn exec() -> Result<(), Error> {
     cfg.merge(args);
 
     // generate a subscriber with the desired log level
+    //
+    // TODO: we should have the logger instantiate sooner, otherwise we cannot
+    // catch errors that are happened before its instantiation.
+    //
+    // Therefore, the logger details such as `type` and `level` cannot be part
+    // of the configuration, since it won't catch any configuration error
+    // otherwise.
+    //
+    // See: <https://github.com/dusk-network/wallet-cli/issues/73>
+    //
     let level = Level::from_str(cfg.logging.level.as_str())?;
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_max_level(level)


### PR DESCRIPTION
- Update CHANGELOG.md
- Change `LoggingConfig` to be optional

  Currently only the fields under `[logging]` section in the `config.toml`
  are optional, therefore the program expects to find *at least* an
  empty section.
  However, the section was introduced in the version `0.11.0`, so loading
  any wallet from an older version will stop the execution.

- Replace `error!` macro with `eprintln!` macro

  This is needed to fix issue #73.
  Currently the logger is instantiated too late, after the configuration
  is parsed, so any configuration errors are not shown.
  Since we're in the binary here and not in the library, it's okay to
  use directly `eprintln!`.

Resolves #73
