### PR TITLE
Fix wrong condition involved `gas.is_enough()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix wrong condition involved `gas.is_enough()`[#91]
 - Fix `balance` subcommand: it didn't work because the address given wasn't claimed
 - Fix BLS keys exported with wrong extensions [#84]
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -362,7 +362,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
                 return Err(Error::AmountIsZero);
             }
             // check gas limits
-            if gas.is_enough() {
+            if !gas.is_enough() {
                 return Err(Error::NotEnoughGas);
             }
 
@@ -405,7 +405,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
                 return Err(Error::AmountIsZero);
             }
             // check if the gas is enough
-            if gas.is_enough() {
+            if !gas.is_enough() {
                 return Err(Error::NotEnoughGas);
             }
 


### PR DESCRIPTION
Fix wrong condition involved `gas.is_enough()` check

The `if` statement involved `gas.is_enough()` was inverted: 
it was returning an error when the gas was enough, and passing when it wasn't.

Resolves #91