### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2022-10-19
+
 ### Added
 
 - Add `default.config.toml` for the default configuration settings [#57]
@@ -365,7 +367,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.11.1...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/dusk-network/wallet-cli/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/dusk-network/wallet-cli/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/dusk-network/wallet-cli/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/dusk-network/wallet-cli/compare/v0.9.0...v0.10.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"


### PR DESCRIPTION

## [0.12.0] - 2022-10-19

### Added

- Add `default.config.toml` for the default configuration settings [#57]
- Add `settings` subcommand to show the current settings [#57]
- Add `--password` as global argument [#57]
- Add `--skip-recovery` to `create` subcommand [#57]
- Add `--file` to `restore` subcommand [#57]
- Add `Settings` type to merge `Config` (from toml) and `WalletArgs` (from CLI) [#57]
- Add `address` module
- Add `gas` module
- Add `settings` module [#57]
- Add `is_enough` method to `Gas`
- Add `Create`, `Restore` and `Settings` for both `Command` and `RunResult` enums [#72]
- Add `LogFormat` and `LogLevel` enums to enforce the set of value from args [#57]
- Add `From block` and `Last block` during fetching
- Add missing documentations
- Add `Seed` type in `store` module
- Add `stake-allow` command [#83]

### Changed

- Change program behavior to quit if wrong seed phrase is given [#49] 
- Change program behavior to have three attempts for entering a password [#46]
- Change error handling to use the `anyhow` crate in `bin`[#87]
- Change error handling to use the `thiserror` crate in `lib`[#87]
- Change `config.toml` format [#57]
- Change from multiple wallets to one wallet for a single profile dir [#72]
- Rename `dusk` module to `currency` module
- Rename `address` subcommand to `addresses`
- Change `set_price` and `set_limit` for `Gas` to works with `Option`
- Change part of the functions to either receive the `password` or the `settings` [#57]
- Move `config` module outside `io` [#57]
- Change few UI strings
- Update rust-toolchain from `nightly-2022-02-19` to `nightly-2022-08-28`

### Removed

- Rename `--data-dir` argument option to `--profile` [#57]
- Remove `--wallet-name` argument option [#72]
- Remove `--network` argument option to chose the network to connect with [#57]
- Remove `interactive` subcommand [#57]
- Remove `--skip-recovery` as global argument [#57]
- Remove `--wait-for-tx` (now all the transaction wait by default) [#57]
- Remove `merge` method from `Config` in favour of `Settings` type [#57]
- Remove `Command::NotSupported` [#57]
- Rename `DEFAULT_GAS_LIMIT`, `DEFAULT_GAS_PRICE`, `MIN_GAS_LIMIT`
- Remove `Addresses` type in favour of `Vec<Address>`
- Remove `refund-addr` arg in `withdraw` command [#86]

### Fixed

- Fix wrong condition involved `gas.is_enough()`[#91]
- Fix `balance` subcommand: it didn't work because the address given wasn't claimed
- Fix BLS keys exported with wrong extensions [#84]

[0.12.0]: https://github.com/dusk-network/wallet-cli/compare/v0.11.1...v0.12.0