### PR TITLE
Expose Prover and add method in Wallet struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ bs58 = "0.4"
 rand = "0.8"
 aes = "0.7"
 
-dusk-wallet-core = "0.14.1-rc"
+dusk-wallet-core = { git = "https://github.com/dusk-network/wallet-core.git" }
 canonical = "0.7"
 canonical_derive = "0.7"
 dusk-hamt = "0.10.0-rc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ bs58 = "0.4"
 rand = "0.8"
 aes = "0.7"
 
-dusk-wallet-core = { git = "https://github.com/dusk-network/wallet-core.git" }
+dusk-wallet-core = "0.14.1-rc"
 canonical = "0.7"
 canonical_derive = "0.7"
 dusk-hamt = "0.10.0-rc"

--- a/src/store.rs
+++ b/src/store.rs
@@ -30,7 +30,7 @@ impl Serializable<64> for Seed {
 
 /// Provides a valid wallet seed to dusk_wallet_core
 #[derive(Clone)]
-pub(crate) struct LocalStore {
+pub struct LocalStore {
     seed: Seed,
 }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -605,8 +605,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
     }
 
     /// Obtain the inner raw wallet
-    pub fn into_wallet(self) -> Option<WalletCore<LocalStore, State, Prover>> {
-        self.wallet
+    pub fn wallet(&self) -> Option<&WalletCore<LocalStore, State, Prover>> {
+        self.wallet.as_ref()
     }
 }
 /// Bls key pair helper structure

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -605,7 +605,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
     }
 
     /// Obtain the inner raw wallet
-    pub fn wallet(&self) -> Option<&WalletCore<LocalStore, State, Prover>> {
+    pub fn get_wallet(&self) -> Option<&WalletCore<LocalStore, State, Prover>> {
         self.wallet.as_ref()
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -603,6 +603,11 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             .find(|a| a.psk == addr.psk)
             .ok_or(Error::AddressNotOwned)
     }
+
+    /// Obtain the inner wallet
+    pub fn get_wallet(self) -> Option<WalletCore<LocalStore, State, Prover>> {
+        self.wallet
+    }
 }
 /// Bls key pair helper structure
 #[derive(Serialize)]

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -604,8 +604,8 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
             .ok_or(Error::AddressNotOwned)
     }
 
-    /// Obtain the inner wallet
-    pub fn get_wallet(self) -> Option<WalletCore<LocalStore, State, Prover>> {
+    /// Obtain the inner raw wallet
+    pub fn into_wallet(self) -> Option<WalletCore<LocalStore, State, Prover>> {
         self.wallet
     }
 }


### PR DESCRIPTION
This makes `Prover` public and adds a method in the `Wallet` to obtain the inner `WalletCore` which can be used to send data to the blockchain easily

Closes #108 