### PR TITLE
Bump to version `0.13.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2022-11-30
+
 ### Changed
 
 - Changed fn signature in `gas::new` to include the gas limit [#116]
@@ -376,7 +378,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.12.0...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/dusk-network/wallet-cli/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/dusk-network/wallet-cli/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/dusk-network/wallet-cli/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/dusk-network/wallet-cli/compare/v0.10.0...v0.11.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"


### PR DESCRIPTION
## [0.13.0] - 2022-11-30

### Changed

- Changed fn signature in `gas::new` to include the gas limit [#116]
- Change `request_gas_limit` fn signature to accept a gas limit option [#116]
- Change (un)stake, allow stake and withdraw default gas limits to sane defaults [#116]
- Change exported consensus keys extension to `.keys` [#114]

[0.13.0]: https://github.com/dusk-network/wallet-cli/compare/v0.12.0...v0.13.0