### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2023-01-12
+
 ### Added
 
 - Add `execute` to create transaction for generic contract calls [#133]
@@ -395,7 +397,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.13.0...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/dusk-network/wallet-cli/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/dusk-network/wallet-cli/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/dusk-network/wallet-cli/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/dusk-network/wallet-cli/compare/v0.11.0...v0.11.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.13.1-rc.0"
+version = "0.14.0"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"


### PR DESCRIPTION
### Added

- Add `execute` to create transaction for generic contract calls [#133]
- Add transaction history [#12]
- Add stake maturity epoch [#128]
- Add staking address display [#105]
- Add stake eligibility info [#124]

### Fixed

- Fix headless balance display [#123]