### PR TITLE
Merge LocalStore and State to access ssk in fetch_notes

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -27,13 +27,13 @@ use crate::settings::{LogFormat, Settings};
 #[cfg(not(windows))]
 use dusk_wallet::TransportUDS;
 
-use dusk_wallet::{Dusk, SecureWalletFile, TransportTCP, Wallet, WalletPath};
+use dusk_wallet::{
+    Dusk, SecureWalletFile, TransportTCP, Wallet, WalletPath, MAX_ADDRESSES,
+};
 
 use config::{Config, TransportMethod};
 use io::{prompt, status};
 use io::{GraphQL, WalletArgs};
-
-const MAX_ADDRESSES: usize = 255;
 
 #[derive(Debug, Clone)]
 pub(crate) struct WalletFile {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::store::LocalStore;
+use crate::clients::StateStore;
 use canonical::CanonError;
 use phoenix_core::Error as PhoenixError;
 use rand_core::Error as RngError;
@@ -14,7 +14,7 @@ use tonic::codegen::http;
 use super::clients;
 /// Wallet core error
 pub(crate) type CoreError =
-    dusk_wallet_core::Error<LocalStore, clients::State, clients::Prover>;
+    dusk_wallet_core::Error<StateStore, StateStore, clients::Prover>;
 
 /// Errors returned by this library
 #[derive(Debug, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,5 @@ pub const MAX_CONVERTIBLE: Dusk = Dusk::MAX;
 pub const MIN_CONVERTIBLE: Dusk = Dusk::new(1);
 /// The length of an epoch in blocks
 pub const EPOCH: u64 = 2160;
+/// The max number of addresses the wallet can have per wallet instance.
+pub const MAX_ADDRESSES: usize = 255;

--- a/src/store.rs
+++ b/src/store.rs
@@ -29,9 +29,9 @@ impl Serializable<64> for Seed {
 }
 
 /// Provides a valid wallet seed to dusk_wallet_core
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct LocalStore {
-    seed: Seed,
+    pub seed: Seed,
 }
 
 impl Store for LocalStore {


### PR DESCRIPTION
1. Merge localstore and State so we can access the local store in the fetch_notes implementation
2. Once we can do that, we can retrieve ssk(s) for the MAX addresses in the wallet and we can generate nuliifier from there
3. Since the fetch_notes in clients.rs fetches ALL the notes, we check if the notes belong to ALL the addresses in the wallet so you only have to call fetch_notes once to cache all the addresses in one wallet.
4. There is still `last_height` in the note data as it is needed by the functions utilising it but there is now one "last_height" per cache inserted in the cache db in the default column family.

Closes #144 