### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2023-06-07
+
 ### Changed
 
 - Cache implementation now uses rocksdb instead of microkelvin [#56]
@@ -415,7 +417,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.14.1...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/dusk-network/wallet-cli/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/dusk-network/wallet-cli/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/dusk-network/wallet-cli/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/dusk-network/wallet-cli/compare/v0.12.0...v0.13.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"


### PR DESCRIPTION
### Changed

- Cache implementation now uses rocksdb instead of microkelvin [#56]

### Fixed

- Throw an error there when specifying a network that does not exist [#143]