### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -425,7 +425,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.15.0...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/dusk-network/wallet-cli/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/dusk-network/wallet-cli/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/dusk-network/wallet-cli/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/dusk-network/wallet-cli/compare/v0.13.0...v0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2023-06-28
+
 ### Changed
 
 - Change cached Note's key to be the nullifier instead of hash [#144]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"


### PR DESCRIPTION
### Changed

- Change cached Note's key to be the nullifier instead of hash [#144]
- Update cache for all the possible addresses at the same time [#144]