### PR TITLE
Calculate psk(s) again on state init to populate cf(s) on cache db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Populate cache database with psk(s) on state init [#158]
+
 ## [0.16.0] - 2023-06-28
 
 ### Changed
@@ -422,6 +426,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#492]: https://github.com/dusk-network/rusk/issues/492
 [#482]: https://github.com/dusk-network/rusk/issues/482
 [#479]: https://github.com/dusk-network/rusk/issues/479
+[#158]: https://github.com/dusk-network/wallet-cli/pull/158
 
 <!-- Releases -->
 

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -212,7 +212,7 @@ impl StateStore {
         data_dir: &Path,
         store: LocalStore,
     ) -> Result<Self, Error> {
-        let cache = Cache::new(data_dir)?;
+        let cache = Cache::new(data_dir, &store)?;
         let inner = Mutex::new(InnerState { client, cache });
 
         Ok(Self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,9 @@ pub enum Error {
         "Network not found, check config.toml, specify network with -n flag"
     )]
     NetworkNotFound,
+    /// The cache database couldn't find column family required
+    #[error("Cache database corrupted")]
+    CacheDatabaseCorrupted,
 }
 
 impl From<dusk_bytes::Error> for Error {


### PR DESCRIPTION
Also throw DatabaseCorrupted error when cannot find CF. This is a new variant because rocksdb::Error doesn't allow you to construct its own instance even with `ErrorKind` (`ErrorKind::Corrupted` would suit well here) but we can always create our own custom ones to provide more comprehensive errors to user

Opened because #153 closed

Closes #149 