### PR TITLE
Decouple balance from fetch_notes/fetch_nullifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add balance display when offline
+
 ### Changed
 
+- Change `connect` and `connect_with_status`to specify if cache sync is required
+- Change spent notes to be in a different ColumnFamily
+- Change `StateClient::fetch_existing_nullifiers` to return empty data.
 - Change `fetch_notes` to use note's position instead of height [#190]
+
+### Removed
+
+- Remove cache sync from `StateClient::fetch_notes`
+- Remove `RuskClient` struct
 
 ### Fixed
 

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -340,7 +340,7 @@ impl Command {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
                 };
-                let notes = wallet.get_all_notes(addr)?;
+                let notes = wallet.get_all_notes(addr).await?;
 
                 let transactions =
                     history::transaction_from_notes(settings, notes).await?;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -68,7 +68,7 @@ async fn connect<F>(
     mut wallet: Wallet<F>,
     settings: &Settings,
     status: fn(&str),
-    block: bool,
+    cache_sync: bool,
 ) -> Wallet<F>
 where
     F: SecureWalletFile + std::fmt::Debug,
@@ -78,7 +78,7 @@ where
             &settings.state.to_string(),
             &settings.prover.to_string(),
             status,
-            block,
+            cache_sync,
         )
         .await;
 
@@ -275,10 +275,10 @@ async fn exec() -> anyhow::Result<()> {
         false => status::interactive,
     };
 
-    // we block until we connect and sync if its not a interactive command
-    let block = cmd.is_some();
+    // if any command is provided, cache must by synced before any operation
+    let cache_sync = cmd.is_some();
 
-    wallet = connect(wallet, &settings, status_cb, block).await;
+    wallet = connect(wallet, &settings, status_cb, cache_sync).await;
 
     // run command
     match cmd {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -134,8 +134,31 @@ impl Cache {
         }))
     }
 
-    /// Returns an iterator over all notes inserted for the given PSK, in order
-    /// of block height.
+    /// Returns an iterator over all unspent notes nullifier for the given PSK.
+    pub(crate) fn unspent_notes_id(
+        &self,
+        psk: &PublicSpendKey,
+    ) -> Result<Vec<BlsScalar>, Error> {
+        let cf_name = format!("{:?}", psk);
+        let mut notes = vec![];
+
+        if let Some(cf) = self.db.cf_handle(&cf_name) {
+            let iterator =
+                self.db.iterator_cf(&cf, rocksdb::IteratorMode::Start);
+
+            for i in iterator {
+                let (id, _) = i?;
+
+                let id = BlsScalar::from_slice(&id)?;
+                notes.push(id);
+            }
+        };
+
+        Ok(notes)
+    }
+
+    /// Returns an iterator over all unspent notes inserted for the given PSK,
+    /// in order of note position.
     pub(crate) fn notes(
         &self,
         psk: &PublicSpendKey,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -23,7 +23,7 @@ type DB = DBWithThreadMode<MultiThreaded>;
 ///
 /// path is the path of the rocks db database
 pub(crate) struct Cache {
-    pub db: DB,
+    db: DB,
 }
 
 impl Cache {

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -203,6 +203,12 @@ impl StateStore {
         })
     }
 
+    pub async fn check_connection(&self) -> Result<(), reqwest::Error> {
+        let client = { self.inner.lock().unwrap().client.clone() };
+
+        client.check_connection().await
+    }
+
     pub async fn register_sync(
         &self,
         sync_tx: Sender<String>,
@@ -210,7 +216,7 @@ impl StateStore {
         let state = self.inner.lock().unwrap();
         let status = self.status;
         let store = self.store.clone();
-        let mut client = state.client.clone();
+        let client = state.client.clone();
         let cache = Arc::clone(&state.cache);
         let sender = Arc::new(sync_tx);
 
@@ -221,16 +227,13 @@ impl StateStore {
                 let sender = Arc::clone(&sender);
                 let _ = sender.send("Syncing..".to_string());
 
-                if let Err(e) =
-                    sync_db(&mut client, &store, cache.as_ref(), status).await
-                {
-                    // Sender should not panic and if it does something is wrong
-                    // and we should abort only when there's an error because it
-                    // important to tell the user that the sync failed
-                    sender.send(format!("Error during sync:.. {e}")).unwrap();
-                }
+                let sync_status =
+                    sync_db(&client, &store, &cache, status).await;
+                let _ = match sync_status {
+                    Ok(_) => sender.send("Syncing Complete".to_string()),
+                    Err(e) => sender.send(format!("Error during sync:.. {e}")),
+                };
 
-                let _ = sender.send("Syncing Complete".to_string());
                 sleep(Duration::from_secs(SYNC_INTERVAL_SECONDS)).await;
             }
         });
@@ -238,14 +241,18 @@ impl StateStore {
         Ok(())
     }
 
-    #[allow(clippy::await_holding_lock)]
     pub async fn sync(&self) -> Result<(), Error> {
-        let state = self.inner.lock().unwrap();
-        let status = self.status;
         let store = self.store.clone();
-        let mut client = state.client.clone();
+        let status = self.status;
+        let (cache, client) = {
+            let state = self.inner.lock().unwrap();
 
-        sync_db(&mut client, &store, state.cache.as_ref(), status).await
+            let cache = state.cache.clone();
+            let client = state.client.clone();
+            (cache, client)
+        };
+
+        sync_db(&client, &store, cache.as_ref(), status).await
     }
 
     pub(crate) fn cache(&self) -> Arc<Cache> {

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -227,9 +227,7 @@ impl StateStore {
                     // Sender should not panic and if it does something is wrong
                     // and we should abort only when there's an error because it
                     // important to tell the user that the sync failed
-                    sender
-                        .send(format!("Error during sync:.. {:?}", e))
-                        .unwrap();
+                    sender.send(format!("Error during sync:.. {e}")).unwrap();
                 }
 
                 let _ = sender.send("Syncing Complete".to_string());

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -73,6 +73,11 @@ impl Prover {
     pub fn set_status_callback(&mut self, status: fn(&str)) {
         self.status = status;
     }
+
+    pub async fn check_connection(&self) -> Result<(), reqwest::Error> {
+        self.state.check_connection().await?;
+        self.prover.check_connection().await
+    }
 }
 
 impl ProverClient for Prover {

--- a/src/clients/sync.rs
+++ b/src/clients/sync.rs
@@ -21,7 +21,7 @@ use crate::{Error, RuskRequest, MAX_ADDRESSES};
 const RKYV_TREE_LEAF_SIZE: usize = size_of::<ArchivedTreeLeaf>();
 
 pub(crate) async fn sync_db(
-    client: &mut RuskHttpClient,
+    client: &RuskHttpClient,
     store: &LocalStore,
     cache: &Cache,
     status: fn(&str),

--- a/src/rusk.rs
+++ b/src/rusk.rs
@@ -14,28 +14,6 @@ use crate::Error;
 /// Supported Rusk version
 const REQUIRED_RUSK_VERSION: &str = "0.6.0";
 
-/// Clients to Rusk services
-#[derive(Clone)]
-pub struct RuskClient {
-    /// HttpClient connected to the state
-    pub state: RuskHttpClient,
-    /// HttpClient connected to the prover
-    pub prover: RuskHttpClient,
-}
-
-impl RuskClient {
-    /// Create a new client specifying rusk address and the prover address
-    pub fn new<S>(rusk_addr: S, prov_addr: S) -> Self
-    where
-        S: Into<String>,
-    {
-        Self {
-            state: RuskHttpClient::new(rusk_addr.into()),
-            prover: RuskHttpClient::new(prov_addr.into()),
-        }
-    }
-}
-
 #[derive(Debug)]
 /// RuskRequesst according to the rusk event system
 pub struct RuskRequest {

--- a/src/rusk.rs
+++ b/src/rusk.rs
@@ -92,7 +92,7 @@ impl RuskHttpClient {
     }
 
     /// Check rusk connection
-    pub async fn check_connection(&self) -> Result<(), Error> {
+    pub async fn check_connection(&self) -> Result<(), reqwest::Error> {
         reqwest::Client::new().post(&self.uri).send().await?;
         Ok(())
     }


### PR DESCRIPTION
Everytime the database is synced, spent notes are moved to a different column family.
This way, calculating the balance doesn't require the network anymore and cache is consistent (see also #188)

Change the `fetch_existing_nullifiers` used by wallet-core to return empty notes.

Ps: deleting notes (instead of move them) results in missing transactions from the history

Resolves #195 
