### PR TITLE
Refactor connection handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add balance display when offline
+- Add `Wallet::sync` method for sync cache update
+- Add `Wallet::register_sync` method for async cache update
 
 ### Changed
 
-- Change `connect` and `connect_with_status`to specify if cache sync is required
+- Change wallet to not sync automatically
 - Change spent notes to be in a different ColumnFamily
 - Change `StateClient::fetch_existing_nullifiers` to return empty data.
 - Change `fetch_notes` to use note's position instead of height [#190]

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -196,6 +196,10 @@ impl Command {
     ) -> anyhow::Result<RunResult> {
         match self {
             Command::Balance { addr, spendable } => {
+                // don't check result of wallet sync, since we support offline
+                // balance
+                let _ = wallet.sync().await;
+
                 let addr = match addr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
@@ -227,6 +231,7 @@ impl Command {
                 gas_limit,
                 gas_price,
             } => {
+                wallet.sync().await?;
                 let sender = match sndr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
@@ -242,6 +247,7 @@ impl Command {
                 gas_limit,
                 gas_price,
             } => {
+                wallet.sync().await?;
                 let addr = match addr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
@@ -257,6 +263,7 @@ impl Command {
                 gas_limit,
                 gas_price,
             } => {
+                wallet.sync().await?;
                 let addr = match addr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
@@ -284,6 +291,7 @@ impl Command {
                 gas_limit,
                 gas_price,
             } => {
+                wallet.sync().await?;
                 let addr = match addr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
@@ -299,6 +307,7 @@ impl Command {
                 gas_limit,
                 gas_price,
             } => {
+                wallet.sync().await?;
                 let addr = match addr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
@@ -327,6 +336,7 @@ impl Command {
                 Ok(RunResult::ExportedKeys(pub_key, key_pair))
             }
             Command::History { addr } => {
+                wallet.sync().await?;
                 let addr = match addr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),


### PR DESCRIPTION
- Remove `cache_sync` from `connect` and `connect_with_status`
- Add `Wallet::sync` method for sync cache update
- Add `Wallet::register_sync` method for async cache update
- Address list can now be performed offline (non interactive)