### PR TITLE
Bump version to `0.20.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2023-11-01
+
 ### Changed
 
 - Change `REQUIRED_RUSK_VERSION` to `0.7.0-rc`
@@ -535,7 +537,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.19.1...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/dusk-network/wallet-cli/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/dusk-network/wallet-cli/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/dusk-network/wallet-cli/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/dusk-network/wallet-cli/compare/v0.18.1...v0.18.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.20.0-rc.0"
+version = "0.20.0"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"


### PR DESCRIPTION
## [0.20.0] - 2023-11-01

### Changed

- Change `REQUIRED_RUSK_VERSION` to `0.7.0-rc`
- Change the Staking Address generation. [#214]
- Change `dusk-wallet-core` to `0.22.0-plonk.0.16` [#214]

[0.20.0]: https://github.com/dusk-network/wallet-cli/compare/v0.19.1...v0.20.0
