### PR TITLE
Adapt wallet-cli to new stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `name` to `export` command 
+
 ### Fixed
 
 - Fix `stake_allow` command [#222] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `seed-file` to `create` command [#226] 
 - Add `name` to `export` command 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `stake_allow` command [#222] 
 
+### Changed
+
+- Change `dusk-wallet-core` to `0.24.0-plonk.0.16-rc.2`
+
 ## [0.20.1] - 2023-11-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `dusk-wallet-core` to `0.24.0-plonk.0.16-rc.2`
+- Change `DEFAULT_MAX_ADDRESSES` from 255 to 25
 
 ## [0.20.1] - 2023-11-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ rocksdb = "0.21"
 flume = "0.10.14"
 reqwest = { version = "0.11", features = ["stream"] }
 
-dusk-wallet-core = "0.22.0-plonk.0.16"
+dusk-wallet-core = "0.24.0-plonk.0.16-rc.2"
 dusk-bytes = "0.1"
 dusk-pki = "0.13"
-rusk-abi = { version = "0.11", default-features = false }
+rusk-abi = { version = "0.12.0-rc", default-features = false }
 phoenix-core = { version = "0.21", features = ["alloc"] }
 dusk-schnorr = { version = "0.14", default-features = false }
 dusk-poseidon = "0.31"

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -35,6 +35,10 @@ pub(crate) enum Command {
         /// Skip wallet recovery phrase (useful for headless wallet creation)
         #[clap(long, action)]
         skip_recovery: bool,
+
+        /// Save recovery phrase to file (useful for headless wallet creation)
+        #[clap(long)]
+        seed_file: Option<PathBuf>,
     },
 
     /// Restore a lost wallet

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -181,6 +181,10 @@ pub(crate) enum Command {
         /// Output directory for the exported keys
         #[clap(short, long)]
         dir: PathBuf,
+
+        /// Name of the files exported [default: staking-address]
+        #[clap(short, long)]
+        name: Option<String>,
     },
 
     /// Show current settings
@@ -322,7 +326,7 @@ impl Command {
                 let tx = wallet.withdraw_reward(addr, gas).await?;
                 Ok(RunResult::Tx(Hasher::digest(tx.to_hash_input_bytes())))
             }
-            Command::Export { addr, dir } => {
+            Command::Export { addr, dir, name } => {
                 let addr = match addr {
                     Some(addr) => wallet.claim_as_address(addr)?,
                     None => wallet.default_address(),
@@ -335,7 +339,7 @@ impl Command {
                 )?;
 
                 let (pub_key, key_pair) =
-                    wallet.export_keys(addr, &dir, &pwd)?;
+                    wallet.export_keys(addr, &dir, name, &pwd)?;
 
                 Ok(RunResult::ExportedKeys(pub_key, key_pair))
             }

--- a/src/bin/interactive.rs
+++ b/src/bin/interactive.rs
@@ -268,6 +268,7 @@ fn menu_op(
         })),
         CMI::Export => AddrOp::Run(Box::new(Command::Export {
             addr: Some(addr),
+            name: None,
             dir: prompt::request_dir("export keys", settings.profile.clone())?,
         })),
         CMI::Back => AddrOp::Back,
@@ -300,6 +301,7 @@ fn menu_op_offline(
     let res = match cmd {
         CMI::Export => AddrOp::Run(Box::new(Command::Export {
             addr: Some(addr),
+            name: None,
             dir: prompt::request_dir("export keys", settings.profile.clone())?,
         })),
         CMI::Back => AddrOp::Back,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub const EPOCH: u64 = 2160;
 /// Max addresses the wallet can store
 pub const MAX_ADDRESSES: usize = get_max_addresses();
 
-const DEFAULT_MAX_ADDRESSES: usize = 255;
+const DEFAULT_MAX_ADDRESSES: usize = 25;
 
 const fn get_max_addresses() -> usize {
     match option_env!("WALLET_MAX_ADDR") {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -666,6 +666,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
         &self,
         addr: &Address,
         dir: &Path,
+        filename: Option<String>,
         pwd: &[u8],
     ) -> Result<(PathBuf, PathBuf), Error> {
         // we're expecting a directory here
@@ -678,7 +679,7 @@ impl<F: SecureWalletFile + Debug> Wallet<F> {
 
         // set up the path
         let mut path = PathBuf::from(dir);
-        path.push(addr.to_string());
+        path.push(filename.unwrap_or(addr.to_string()));
 
         // export public key to disk
         let bytes = keys.0.to_bytes();


### PR DESCRIPTION
- Bump wallet-core to `0.24.0-plonk.0.16-rc.2`
- Bump rusk-abi to `0.12-0.rc`
- Add `name` to `export` command
- Add `seed-file` to `create` command
- Change `DEFAULT_MAX_ADDRESSES` from 255 to 25