### PR TITLE
Release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2024-2-28
+
 ### Changed
 
+- Change `REQUIRED_RUSK_VERSION` to `0.7.0`
 - Update unclear error message [#235]
 - Change provisioner key password prompt message [#238]
 
@@ -575,7 +578,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.21.0...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/dusk-network/wallet-cli/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/dusk-network/wallet-cli/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/dusk-network/wallet-cli/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/dusk-network/wallet-cli/compare/v0.19.1...v0.20.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"

--- a/src/rusk.rs
+++ b/src/rusk.rs
@@ -12,7 +12,7 @@ use rkyv::Archive;
 use crate::Error;
 
 /// Supported Rusk version
-const REQUIRED_RUSK_VERSION: &str = "0.7.0-rc";
+const REQUIRED_RUSK_VERSION: &str = "0.7.0";
 
 #[derive(Debug)]
 /// RuskRequesst according to the rusk event system


### PR DESCRIPTION
## [0.22.0] - 2024-2-28

### Changed

- Change `REQUIRED_RUSK_VERSION` to `0.7.0`
- Update unclear error message [#235]
- Change provisioner key password prompt message [#238]

### Removed

- Remove `stake_allow` command

[0.22.0]: https://github.com/dusk-network/wallet-cli/compare/v0.21.0...v0.22.0