### PR TITLE
Release 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2024-3-27
+
 ### Added
 
 - Add support for `WALLET_MAX_ADDR` lower than `6` [#244]
@@ -592,7 +594,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.22.0...HEAD
+[unreleased]: https://github.com/dusk-network/wallet-cli/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/dusk-network/wallet-cli/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/dusk-network/wallet-cli/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/dusk-network/wallet-cli/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/dusk-network/wallet-cli/compare/v0.20.0...v0.20.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 autobins = false
 description = "A library providing functionalities to create wallets compatible with Dusk Network"


### PR DESCRIPTION
## [0.22.1](https://github.com/dusk-network/wallet-cli/compare/v0.22.0...v0.22.1) - 2024-3-27

### Added

- Add support for `WALLET_MAX_ADDR` lower than `6` [#244]

### Changed

- Change rusk-wallet to wait for tx to be included

### Fixed

- Fix tx history to avoid useless calls [#243]